### PR TITLE
Mount workspace in action jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
         id: hello
         with:
           image: alpine
-          commands: |
+          run: |
             echo "$VAR_A $VAR_B from $EAI_CONSOLE_URL"
             ls /data
           data: shared.dataset.coco:/data:ro

--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ export ROLE=$(eai role new $ACCOUNT. --fields id --no-header)
 export ACCOUNT_URN=$(eai account get $ACCOUNT --fields urn --no-header)
 eai role policy new $ROLE --action account:get --action job:new --resource $ACCOUNT_URN
 eai role policy new $ROLE --action job:get --resource $ACCOUNT_URN:job:\*
+export DATA_URN=$(eai data get $DATA --fields urn --no-header)
+eai role policy new $ROLE --action data:\* --resource $DATA_URN
 export JOB=$(eai job new \
     --account $ACCOUNT \
     -d $DATA:/runner:rw \
+    -e RUNNER_DATA=$DATA \
     -e "RUNNER_CONFIG=$CONFIG" \
     -i registry.console.elementai.com/shared.image/github-actions-runner \
     --name $JOB_NAME \

--- a/action.yml
+++ b/action.yml
@@ -3,8 +3,8 @@ description: Run a job inside the cluster
 inputs:
   image:
     description: string - Docker image.
-  commands:
-    description: string - Commands (for more than one, use a multiline string with one per line).
+  run:
+    description: string - Commands to run (for more than one, you can use a multiline string).
   data:
     description: string - Data to mount (for more than one, use a multiline string with one per line).
   env:

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const run = require("./run");
 
 const parseBoolean = (input) => input === "true";
 const parseCommand = (commands) => ["/bin/sh", "-ce", commands];
+const parseString = (input) => input;
 const parseStringArray = (input) => input.split("\n");
 const parseTag = (input) => {
   const split = input.indexOf("=");
@@ -19,9 +20,9 @@ const createFields = (fields) => () => {
   return Object.keys(r).length > 0 ? r : undefined;
 };
 
-const createField = ({ name, options, parse } = {}) => (field) => {
+const createField = ({ name, options, parse = parseString } = {}) => (field) => {
   const input = core.getInput(name || field, options);
-  return input ? (parse ? parse(input) : input) : undefined;
+  return input === "" ? undefined : parse(input);
 };
 
 const getJobSpec = createFields({

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const createField = ({ name, options, parse = parseString } = {}) => (field) => 
 
 const getJobSpec = createFields({
   // Execution
-  command: createField({ name: "commands", parse: parseCommand }),
+  command: createField({ name: "run", parse: parseCommand }),
   data: createField({ parse: parseStringArray }),
   environmentVars: createField({ name: "env", parse: parseStringArray }),
   image: createField({ options: { required: true } }),


### PR DESCRIPTION
* Mount runner data to action job's home so all action jobs and the runner job share the same repo.
The checkout action clones the repo in
`<runner data>/_work/example-repo/example-repo`
This is now mounting
`<runner data>/_work/example-repo:/home/toolkit:rw`
and adding the environment variable
`HOME=/home/toolkit`
as well as setting the workdir to
`/home/toolkit/example-repo`
* Simplify nested ternary expressions with a default identity parser.
* Rename parameter `commands` to `run` to be uniform with the default GitHub workflow action.